### PR TITLE
types: re-export PropsWithChildren type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,4 +33,6 @@ export const html = () =>
             }
         })
 
+export type { PropsWithChildren } from '@kitajs/html'
+
 export default html


### PR DESCRIPTION
Maybe I am missing a way to do this currently, but I think for creating reusable JSX components that you can pass children to without having to explicitly use the `children` prop, we should re-export the `PropsWithChildren` type from `@kitajs/html`.

It might be more sensible to export this from a separate file, so that you can import like:

```tsx
import type { PropsWithChildren } from "@elysiajs/html/jsx";
```

but I would like your opinion too