### PR TITLE
Fix HtmlButtonTag.disabled type

### DIFF
--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -76,7 +76,7 @@ declare namespace JSX {
     interface HtmlButtonTag extends HtmlTag {
         action?: string
         autofocus?: string
-        disabled?: string
+        disabled?: boolean
         enctype?: string
         form?: string
         method?: string


### PR DESCRIPTION
Fixes the type of HTML button attribute `disabled`