### PR TITLE
test(index.test.ts): add new test cases for HTML vs No HTML header responses to ensure correct header inheritance and content type handling

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,3 +61,43 @@ describe('HTML', () => {
         expect(res.headers.get('Content-type')).toContain('text/html; charset=utf8')
     })
 })
+
+describe('HTML vs No html - header', () => {
+    it('inherits header plain response when using the html plugin', async () => {
+        const app = new Elysia().use(html()).get('/', ({ html, set }) => {
+            set.headers.Server = 'Elysia'
+            return 'Hello'
+        })
+        const res = await app.handle(req('/'))
+        expect(res.headers.get('Server')).toBe('Elysia')
+    })
+
+    it('inherits header plain response not using the html plugin', async () => {
+        const app = new Elysia().get('/', ({ set }) => {
+            set.headers.Server = 'Elysia'
+            return 'Hello'
+        })
+        const res = await app.handle(req('/'))
+        expect(res.headers.get('Server')).toBe('Elysia')
+        expect(res.headers.get('Content-Type')).toBe(null)
+    })
+
+    it('inherits header json response when using the html plugin', async () => {
+        const app = new Elysia().use(html()).get('/', ({ html, set }) => {
+            set.headers.Server = 'Elysia'
+            return {'Hello': 1}
+        })
+        const res = await app.handle(req('/'))
+        expect(res.headers.get('Server')).toBe('Elysia')
+    })
+
+    it('inherits header json response not using the html plugin', async () => {
+        const app = new Elysia().get('/', ({ set }) => {
+            set.headers.Server = 'Elysia'
+            return {'Hello': 1}
+        })
+        const res = await app.handle(req('/'))
+        expect(res.headers.get('Server')).toBe('Elysia')
+        expect(res.headers.get('Content-Type')).toBe('application/json;charset=utf-8')
+    })
+})


### PR DESCRIPTION
**WIP**

Right now this only add two broken test cases.

The problem is:
- when the html plugin is not used and a plain text, object, ... response is returned, it gets automatically convverted to a Resonse, and the headers are added
- when the html plugin is used, but not applied in the handler, this automatic mapping to a Response with applying the header does not happen (see the two sample failing test cases)