### PR TITLE
fix: handlerPossibleHtml should keep the original response if not html

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -61,7 +61,7 @@ export function html(options: HtmlOptions = {}) {
 					return new Response(response)
 				}
 
-				return undefined
+				return value
 			}
 		)
 

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -77,4 +77,19 @@ describe('HTML', () => {
 			'text/html; charset=utf8'
 		)
 	})
+
+	it('should keep the original request when the response is not html', async () => {
+		const app = new Elysia()
+			.use(html())
+			.onError(() => {
+				return new Response('ok')
+			})
+			.get('/', () => {
+				throw 'error'
+			})
+
+		let res = await app.handle(request('/'))
+		expect(res.status).toBe(200)
+		expect(await res.text()).toBe('ok')
+	})
 })


### PR DESCRIPTION
## Description

When for example throwing an error in controller and using `@elysiajs/html`, the when transforming the response in an `onError` hook. The response was lost since `handlerPossibleHtml` will remove it. This PR fixes that issue
